### PR TITLE
fix(rcon): include actual error in GetStatus failure message

### DIFF
--- a/backend/controller/rcon.go
+++ b/backend/controller/rcon.go
@@ -44,7 +44,7 @@ func ChangeMap(c *gin.Context) {
 func GetStatus(c *gin.Context) {
 	conn, err := getRconConnection()
 	if err != nil {
-		FailWithError(c, http.StatusInternalServerError, "服务器连接失败，可能服务器重启中或未启动")
+		FailWithError(c, http.StatusInternalServerError, "服务器连接失败: %v", err)
 		return
 	}
 	defer conn.Close()


### PR DESCRIPTION
## Problem

The `GetStatus()` function in `backend/controller/rcon.go` discards the real RCON connection error and returns a hardcoded generic message:

```go
FailWithError(c, http.StatusInternalServerError, "服务器连接失败，可能服务器重启中或未启动")
```

This makes debugging RCON issues impossible without direct log access. Other RCON functions (ChangeMap, KickUser, etc.) already use `%v` to include the actual error.

## Fix

Changed to include the actual error via format string:

```go
FailWithError(c, http.StatusInternalServerError, "服务器连接失败: %v", err)
```

## Testing

- Verified the error message now shows the actual failure reason (e.g., `rcon: authentication failed`) instead of the generic message
- No functional changes - only the error message format is modified
- Consistent with existing patterns in the same file