### PR TITLE
fix(docker): make RCON password setup resilient to missing line in server.cfg

### DIFF
--- a/manifest/docker/start.sh
+++ b/manifest/docker/start.sh
@@ -18,12 +18,21 @@ else
 fi
 
 # 获取环境变量中的RCON密码，写入到server.cfg
+# 使用 sed 替换已有行，若行不存在则追加
 if [ -n "${L4D2_RCON_PASSWORD}" ]; then
     echo "设置RCON密码..."
-    sed -i "s/^rcon_password .*/rcon_password \"${L4D2_RCON_PASSWORD}\"/" /l4d2/left4dead2/cfg/server.cfg
+    if grep -q "^rcon_password" /l4d2/left4dead2/cfg/server.cfg 2>/dev/null; then
+        sed -i "s/^rcon_password .*/rcon_password \"${L4D2_RCON_PASSWORD}\"/" /l4d2/left4dead2/cfg/server.cfg
+    else
+        echo "rcon_password \"${L4D2_RCON_PASSWORD}\"" >> /l4d2/left4dead2/cfg/server.cfg
+    fi
 else
     echo "警告：未设置RCON密码，使用默认密码"
-    sed -i "s/^rcon_password .*/rcon_password \"laoyutangnb!\"/" /l4d2/left4dead2/cfg/server.cfg
+    if grep -q "^rcon_password" /l4d2/left4dead2/cfg/server.cfg 2>/dev/null; then
+        sed -i "s/^rcon_password .*/rcon_password \"laoyutangnb!\"/" /l4d2/left4dead2/cfg/server.cfg
+    else
+        echo "rcon_password \"laoyutangnb!\"" >> /l4d2/left4dead2/cfg/server.cfg
+    fi
 fi
 
 # 设置服务器端口，环境变量L4D2_PORT


### PR DESCRIPTION
## Problem

The current `sed -i "s/^rcon_password .*/..."` command in `manifest/docker/start.sh` silently fails when `server.cfg` has no `rcon_password` line.

### How it breaks

1. First boot: template `server.cfg.100tick` is copied, `rcon_password` line exists → sed works
2. Manager writes MANAGER-CUSTOM lines to `server.cfg` (e.g. `sm_cvar sv_allow_lobby_connect_only`)
3. Container restart: `.initialized` marker exists → template NOT re-copied
4. If `rcon_password` line was lost, sed silently fails → RCON becomes **permanently inaccessible**

This was observed on a production server where the Manager was showing "Server connection failed" for RCON after restart.

## Fix

Check if `rcon_password` line exists before using sed. If missing, append instead:

```bash
if grep -q "^rcon_password" /l4d2/left4dead2/cfg/server.cfg 2>/dev/null; then
    sed -i "s/^rcon_password .*/rcon_password \${PASSWORD}\/" ...
else
    echo "rcon_password \${PASSWORD}\" >> ...
fi
```

## Testing

- Tested on both Docker and bare-metal L4D2 servers
- Normal case (line exists): sed works as before
- Recovery case (line missing): password is appended correctly
- Server restarts with RCON working after Manager modification